### PR TITLE
shields_generator.dm & asteroid_magnet.dm - (UN)WRENCH (UN)ANCHORING FIX

### DIFF
--- a/code/modules/shield_generators/shield_generator.dm
+++ b/code/modules/shield_generators/shield_generator.dm
@@ -3,7 +3,7 @@
 	desc = "A heavy-duty shield generator and capacitor, capable of generating energy shields at large distances."
 	icon = 'icons/obj/machines/shielding.dmi'
 	icon_state = "generator0"
-	anchored = TRUE
+	anchored = 0
 	density = 1
 	base_type = /obj/machinery/shield_generator
 	construct_state = /decl/machine_construction/default/panel_closed
@@ -525,3 +525,16 @@
 			turfs.Add(T)
 
 	return turfs
+
+/obj/machinery/shield_generator/attackby(obj/item/W, mob/user)
+	if(IS_WRENCH(W))
+		if(running==SHIELD_OFF)
+			src.anchored=!src.anchored
+
+			if (!src.anchored)
+				user.show_message(text("<span cRlass='warning'>[src] can now be moved.</span>"))
+
+			if (src.anchored)
+				user.show_message(text("<span class='warning'>[src] is now secured.</span>"))
+		else
+			to_chat(user, "Turn off [src] first.")

--- a/mods/persistence/modules/overmap/asteroid_magnet.dm
+++ b/mods/persistence/modules/overmap/asteroid_magnet.dm
@@ -10,6 +10,7 @@
 	icon = 'icons/obj/machines/power/fusion.dmi'
 	icon_state = "injector0"
 	density = 1
+	anchored = 0
 	idle_power_usage = 0.1 KILOWATTS // Displays etc. Actual attraction of the asteroid takes far more.
 	active_power_usage = 25 KILOWATTS
 	construct_state = /decl/machine_construction/default/panel_closed
@@ -179,6 +180,17 @@
 		/obj/item/stock_parts/keyboard = 1,
 		/obj/item/stock_parts/power/apc/buildable = 1
 	)
+
+/obj/machinery/asteroid_magnet/attackby(obj/item/W, mob/user)
+	if(IS_WRENCH(W))
+		src.anchored = !src.anchored
+
+		if (!src.anchored)
+			user.show_message(text("<span class='warning'>[src] can now be moved.</span>"))
+
+		else if (src.anchored)
+			user.show_message(text("<span class='warning'>[src] is now secured.</span>"))
+
 
 #undef ASTEROID_SIZE
 #undef MAX_OBJS


### PR DESCRIPTION
Adds wrenching and unwrenching for both.  Removes default anchor state.

<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Authorship
<!-- Describe original authors of changes to credit them. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
bugfix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->